### PR TITLE
Fix typo/grammar error

### DIFF
--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -13,7 +13,7 @@ Plugins
 What are EMSM plugins?
 ----------------------
 
-The EMSM plugins work as *frontend* for the EMSM and automize minecraft server
+The EMSM plugins work as *frontend* for the EMSM and automate minecraft server
 tasks.
 
 How to write a plugin


### PR DESCRIPTION
The word 'automize' does not exist in English and should be 'automate'. Hope this helps and does not annoy! ;-)