### PR TITLE
Custom server type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ nosetests.xml
 .project
 .pydevproject
 
+# PyCharm
+.idea
+
 # EMSM
 # ====
 

--- a/docs/source/how_to/configuration.rst
+++ b/docs/source/how_to/configuration.rst
@@ -140,6 +140,8 @@ section:
     server. If your server is not listed, you can create a new plugin, which
     provides a :class:`server wrapper <emsm.core.server.BaseServerWrapper>`.
 
+    There is a special ``custom`` server type. This is for servers that are not supported by emsm server plugin. If you use the ``custom`` type you must also override the server's start_command. (read below)
+
 You can overridde some global plugin and server options for each world:
 
 .. code-block:: ini
@@ -168,6 +170,19 @@ not the current server of the world:
 
 Check out the :ref:`plugins` documentation, if you want to know more about their
 configuration.
+
+If you choose to use the ``custom`` server type, you should always provide a start_command (and preferably an exe_path) like this:
+
+.. code-block:: ini
+
+    [server:custom]
+    start_command = java -jar {instance_dir}/server/ftb_direwolf20_1_10/{server_exe} nogui
+    exe_path = FTBserver-1.10.2-12.18.2.2171-universal.jar
+
+Note the ``{instance_dir}`` placeholder in the start_command value. This will be replaced with the ``instace_dir`` parameter passed to ``emsm.run()``.
+
+This way you can use any minecraft servers just make sure, you copy the required files to the world dir manually.
+
 
 Example
 '''''''

--- a/emsm/core/worlds.py
+++ b/emsm/core/worlds.py
@@ -280,9 +280,10 @@ class WorldWrapper(object):
                             .format(self._name))
 
         # server
-        if not self._conf["server"] in self._app.server().get_names():
-            raise ValueError("{} - conf:server does not exist"\
-                             .format(self._name))
+        if not self._conf["server"] == "custom":
+            if not self._conf["server"] in self._app.server().get_names():
+                raise ValueError("{} - conf:server does not exist"\
+                                 .format(self._name))
         return None
 
     def worldpath_to_ospath(self, rel_path):
@@ -677,6 +678,7 @@ class WorldWrapper(object):
                 # Fire off the start command.
                 sys_cmd = shlex.split(sys_cmd)
                 subprocess.call(sys_cmd)
+
         finally:
             # We may have not the rights to change back.
             # E.g.: The EMSM was invoked in /root, but we dropped privileges.


### PR DESCRIPTION
I've been playing around with this little modification in the weekend.

The idea behind is you don't need to write plugins for different servers. You just set the world's server config key to custom, and override the start command in [server:custom]. This way you just set up your server basically anywhere in the filesystem, copy necessary files to world dir, and hit --start.

The only feature lost here is the automatic installation / update of the server.

I've also updated the documentation, but i was not able to compile it to html. It may have flaws.
Please note that i'm also new to python (first time i've seen python code), so the implementation may not be the best.

If you have any suggestions, or remark, feel free to comment.