### PR TITLE
Update forge to current

### DIFF
--- a/emsm/core/server.py
+++ b/emsm/core/server.py
@@ -763,6 +763,25 @@ class Vanilla_1_16(VanillaBase):
         return re.compile(".* \[SEVERE\] .*", re.MULTILINE)
 
 
+class Vanilla_1_18(VanillaBase):
+
+    @classmethod
+    def name(self):
+        return "vanilla 1.18"
+
+    def default_url(self):
+        return "https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar";
+
+    def log_path(self):
+        return "./logs/latest.log"
+
+    def log_start_re(self):
+        return re.compile("^.*Starting minecraft server version 1\.18\.2.*")
+
+    def log_error_re(self):
+        return re.compile(".* \[SEVERE\] .*", re.MULTILINE)
+
+
 # MinecraftForge
 # ''''''''''''''
 

--- a/emsm/core/server.py
+++ b/emsm/core/server.py
@@ -997,6 +997,24 @@ class MinecraftForge_1_15(MinecraftForgeBase, Vanilla_1_15):
         return os.path.join(self.directory(), filename)
 
 
+class MinecraftForge_1_16(MinecraftForgeBase, Vanilla_1_16):
+
+    @classmethod
+    def name(self):
+        return "minecraft forge 1.16"
+
+    def default_url(self):
+        # 1.16.5
+        return "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.16.5-36.1.0/forge-1.16.5-36.1.0-installer.jar"
+
+    def exe_path(self):
+        filenames = [filename \
+                     for filename in os.listdir(self.directory()) \
+                     if re.match("^forge-1\.16.*.jar$", filename)]
+        filename = filenames[0]
+        return os.path.join(self.directory(), filename)
+
+
 # Bungeecord
 # ''''''''''
 

--- a/emsm/core/server.py
+++ b/emsm/core/server.py
@@ -751,7 +751,7 @@ class Vanilla_1_16(VanillaBase):
         return "vanilla 1.16"
 
     def default_url(self):
-        return "https://launcher.mojang.com/v1/objects/a412fd69db1f81db3f511c1463fd304675244077/server.jar";
+        return "https://launcher.mojang.com/v1/objects/a412fd69db1f81db3f511c1463fd304675244077/server.jar"
 
     def log_path(self):
         return "./logs/latest.log"
@@ -770,7 +770,7 @@ class Vanilla_1_18(VanillaBase):
         return "vanilla 1.18"
 
     def default_url(self):
-        return "https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar";
+        return "https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar"
 
     def log_path(self):
         return "./logs/latest.log"
@@ -1371,6 +1371,7 @@ class ServerManager(object):
             Vanilla_1_14,
             Vanilla_1_15,
             Vanilla_1_16,
+            Vanilla_1_18,
             MinecraftForge_1_6,
             MinecraftForge_1_7,
             MinecraftForge_1_8,

--- a/emsm/core/server.py
+++ b/emsm/core/server.py
@@ -961,6 +961,24 @@ class MinecraftForge_1_13(MinecraftForgeBase, Vanilla_1_13):
         return os.path.join(self.directory(), filename)
 
 
+class MinecraftForge_1_14(MinecraftForgeBase, Vanilla_1_14):
+
+    @classmethod
+    def name(self):
+        return "minecraft forge 1.14"
+
+    def default_url(self):
+        # 1.14.4
+        return "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.14.4-28.1.116/forge-1.14.4-28.1.116-installer.jar"
+
+    def exe_path(self):
+        filenames = [filename \
+                     for filename in os.listdir(self.directory()) \
+                     if re.match("^forge-1\.14.*.jar$", filename)]
+        filename = filenames[0]
+        return os.path.join(self.directory(), filename)
+
+
 # Bungeecord
 # ''''''''''
 
@@ -1305,6 +1323,7 @@ class ServerManager(object):
             MinecraftForge_1_11,
             MinecraftForge_1_12,
             MinecraftForge_1_13,
+            MinecraftForge_1_14,
             BungeeCordServerWrapper,
             Spigot,
             Spigot_1_8,

--- a/emsm/core/server.py
+++ b/emsm/core/server.py
@@ -882,7 +882,7 @@ class MinecraftForge_1_8(MinecraftForgeBase, Vanilla_1_8):
         return "minecraft forge 1.8"
 
     def default_url(self):
-        return "http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.8.9-11.15.1.1722/forge-1.8.9-11.15.1.1722-installer.jar"
+        return "http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.8.9-11.15.1.2318-1.8.9/forge-1.8.9-11.15.1.2318-1.8.9-installer.jar"
 
     def exe_path(self):
         filenames = [filename \
@@ -899,7 +899,7 @@ class MinecraftForge_1_10(MinecraftForgeBase, Vanilla_1_10):
         return "minecraft forge 1.10"
 
     def default_url(self):
-        return "http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.10.2-12.18.0.2008/forge-1.10.2-12.18.0.2008-installer.jar"
+        return "http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.10.2-12.18.3.2511/forge-1.10.2-12.18.3.2511-installer.jar"
 
     def exe_path(self):
         filenames = [filename \
@@ -916,7 +916,7 @@ class MinecraftForge_1_11(MinecraftForgeBase, Vanilla_1_11):
         return "minecraft forge 1.11"
 
     def default_url(self):
-        return "http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.11.2-13.20.0.2228/forge-1.11.2-13.20.0.2228-installer.jar"
+        return "http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.11.2-13.20.1.2588/forge-1.11.2-13.20.1.2588-installer.jar"
 
     def exe_path(self):
         filenames = [filename \
@@ -933,7 +933,7 @@ class MinecraftForge_1_12(MinecraftForgeBase, Vanilla_1_12):
         return "minecraft forge 1.12"
 
     def default_url(self):
-        return "http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.12.2-14.23.5.2854/forge-1.12.2-14.23.5.2854-installer.jar"
+        return "http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.12.2-14.23.5.2855/forge-1.12.2-14.23.5.2855-installer.jar"
 
     def exe_path(self):
         filenames = [filename \
@@ -969,7 +969,7 @@ class MinecraftForge_1_14(MinecraftForgeBase, Vanilla_1_14):
 
     def default_url(self):
         # 1.14.4
-        return "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.14.4-28.1.116/forge-1.14.4-28.1.116-installer.jar"
+        return "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.14.4-28.2.0/forge-1.14.4-28.2.0-installer.jar"
 
     def exe_path(self):
         filenames = [filename \
@@ -987,7 +987,7 @@ class MinecraftForge_1_15(MinecraftForgeBase, Vanilla_1_15):
 
     def default_url(self):
         # 1.15.2
-        return "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.15.2-31.0.1/forge-1.15.2-31.0.1-installer.jar"
+        return "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.15.2-31.2.0/forge-1.15.2-31.2.0-installer.jar"
 
     def exe_path(self):
         filenames = [filename \

--- a/emsm/core/server.py
+++ b/emsm/core/server.py
@@ -943,6 +943,24 @@ class MinecraftForge_1_12(MinecraftForgeBase, Vanilla_1_12):
         return os.path.join(self.directory(), filename)
 
 
+class MinecraftForge_1_13(MinecraftForgeBase, Vanilla_1_13):
+
+    @classmethod
+    def name(self):
+        return "minecraft forge 1.13"
+
+    def default_url(self):
+        # 1.13.2
+        return "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.13.2-25.0.219/forge-1.13.2-25.0.219-installer.jar"
+
+    def exe_path(self):
+        filenames = [filename \
+                     for filename in os.listdir(self.directory()) \
+                     if re.match("^forge-1\.13.*.jar$", filename)]
+        filename = filenames[0]
+        return os.path.join(self.directory(), filename)
+
+
 # Bungeecord
 # ''''''''''
 
@@ -1286,6 +1304,7 @@ class ServerManager(object):
             MinecraftForge_1_10,
             MinecraftForge_1_11,
             MinecraftForge_1_12,
+            MinecraftForge_1_13,
             BungeeCordServerWrapper,
             Spigot,
             Spigot_1_8,

--- a/emsm/core/server.py
+++ b/emsm/core/server.py
@@ -979,6 +979,24 @@ class MinecraftForge_1_14(MinecraftForgeBase, Vanilla_1_14):
         return os.path.join(self.directory(), filename)
 
 
+class MinecraftForge_1_15(MinecraftForgeBase, Vanilla_1_15):
+
+    @classmethod
+    def name(self):
+        return "minecraft forge 1.15"
+
+    def default_url(self):
+        # 1.15.2
+        return "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.15.2-31.0.1/forge-1.15.2-31.0.1-installer.jar"
+
+    def exe_path(self):
+        filenames = [filename \
+                     for filename in os.listdir(self.directory()) \
+                     if re.match("^forge-1\.15.*.jar$", filename)]
+        filename = filenames[0]
+        return os.path.join(self.directory(), filename)
+
+
 # Bungeecord
 # ''''''''''
 
@@ -1324,6 +1342,7 @@ class ServerManager(object):
             MinecraftForge_1_12,
             MinecraftForge_1_13,
             MinecraftForge_1_14,
+            MinecraftForge_1_15,
             BungeeCordServerWrapper,
             Spigot,
             Spigot_1_8,

--- a/emsm/core/server.py
+++ b/emsm/core/server.py
@@ -675,7 +675,7 @@ class Vanilla_1_12(VanillaBase):
         return "vanilla 1.12"
 
     def default_url(self):
-        return "https://launcher.mojang.com/v1/objects/886945bfb2b978778c3a0288fd7fab09d315b25f/server.jar"
+        return "https://s3.amazonaws.com/Minecraft.Download/versions/1.12.2/minecraft_server.1.12.2.jar"
 
     def log_path(self):
         return "./logs/latest.log"
@@ -933,7 +933,7 @@ class MinecraftForge_1_12(MinecraftForgeBase, Vanilla_1_12):
         return "minecraft forge 1.12"
 
     def default_url(self):
-        return "http://files.minecraftforge.net/maven/net/minecraftforge/forge/1.12.2-14.23.5.2855/forge-1.12.2-14.23.5.2855-installer.jar"
+        return "https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.12.2-14.23.5.2854/forge-1.12.2-14.23.5.2854-installer.jar"
 
     def exe_path(self):
         filenames = [filename \


### PR DESCRIPTION
This updates the forge support to current links, and adds support for minecraft versions through 1.16.5.

